### PR TITLE
ci: pin GitHub Actions to SHAs (ENG-921)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -32,9 +32,9 @@ jobs:
 
       - run: mkdocs build
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site/
 
@@ -46,4 +46,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary

Pin every GitHub Action in `docs.yml` to a full commit SHA with the major tag preserved as a trailing comment, plus a new `github-actions` Dependabot config so the SHAs and tag comments stay up to date.

Mutable `@vN` tags can be silently repointed; pinning to a 40-char SHA makes the action reference immutable. No version bumps were needed in this repo (everything was already on a current major) so no behavior change is intended.

### Pinned actions

- `actions/checkout` v4 `34e114876b0b11c390a56381ad16ebd13914f8d5`
- `actions/setup-python` v5 `a26af69be951a213d495a4c3e4e4022e16d87065`
- `actions/configure-pages` v5 `983d7736d9b0ae728b81ab479565c72886d7745b`
- `actions/upload-pages-artifact` v3 `56afc609e74202658d3ffba0e8f6dda462b719fa`
- `actions/deploy-pages` v4 `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e`

## Test plan

- [ ] CI `build` job runs cleanly on this PR
- [ ] Next `main` push deploys to GitHub Pages as before
- [ ] Dependabot picks up the new `github-actions` ecosystem

Refs https://linear.app/signadot/issue/ENG-921
